### PR TITLE
Swallow parsing errors re: more_from_developer

### DIFF
--- a/lib/market_bot/play/app.rb
+++ b/lib/market_bot/play/app.rb
@@ -115,14 +115,22 @@ module MarketBot
           end.compact.uniq
         end
 
-        h2_more = doc.at_css("h2:contains(\"#{result[:developer]}\")")
-        if h2_more
-          more_divs                    = h2_more.parent.next.children
-          result[:more_from_developer] = more_divs.search('a').select do |a|
-            a['href'].start_with?('/store/apps/details')
-          end.map do |a|
-            { package: a['href'].split('?id=').last.strip }
-          end.compact.uniq
+        begin
+          h2_more = doc.at_css("h2:contains(\"#{result[:developer]}\")")
+          if h2_more
+            more_divs                    = h2_more.parent.next.children
+            result[:more_from_developer] = more_divs.search('a').select do |a|
+              a['href'].start_with?('/store/apps/details')
+            end.map do |a|
+              { package: a['href'].split('?id=').last.strip }
+            end.compact.uniq
+          end
+        rescue
+          # :more_from_developer is not important for our purposes; ignore any parsing errors from this block
+          #
+          # TODO: Maybe this gem should "fail open" when it encounters parsing errors, s.t. values returned for various
+          # keys could be some class of object that indicates that a non-critical error occurred
+          # (but not raise an Exception).
         end
 
         node = doc.at_css('img[alt="Cover art"]')


### PR DESCRIPTION
:more_from_developer is not important for our purposes; ignore any parsing errors from this block

TODO: Maybe this gem should "fail open" when it encounters parsing errors, s.t. values returned for various keys could be some class of object that indicates that a non-critical error occurred (but not raise an Exception).