### PR TITLE
Additional fix due to developer div not existing [TENJIN-20464]

### DIFF
--- a/lib/market_bot/play/app.rb
+++ b/lib/market_bot/play/app.rb
@@ -85,11 +85,9 @@ module MarketBot
             result[:categories_urls] = ["https://play.google.com/store/apps/category/#{data['applicationCategory']}"]
 
             result[:content_rating] = data['contentRating']
-            data.dig('aggregateRating', 'ratingValue')
 
-            developer_div          = doc.at_css('h1[itemprop="name"]').next
             result[:developer]     = data.dig('author', 'name')
-            result[:developer_url] = developer_div.css('a').attr('href').value
+            result[:developer_url] = data.dig('author', 'url')
             result[:developer_id]  = result[:developer_url].split('?id=').last.strip
 
             result[:rating] = data.dig('aggregateRating', 'ratingValue')
@@ -97,7 +95,7 @@ module MarketBot
 
             result[:cover_image_url] = data['image']
 
-            result[:updated] ||= text = doc.search("meta[itemprop='description']")[0].parent.children.last.children.last.children.last.text
+            result[:updated] ||= text = doc.at('meta[itemprop="description"] + div + div > div:first > div[2]').text
 
             unless result[:current_version]
               text    = doc.search('//script[starts-with(text(),"AF_initDataCallback({key: \'ds:4\'")]').text


### PR DESCRIPTION
Follow up to https://github.com/tenjin/market_bot/pull/3

Fields such as developer, cover_image_url, etc. were still not getting returned. This was due to a generic rescue clause that short-circuits the setting of various fields, but the point at which we fail is at `developer_div = doc.at_css('h1[itemprop="name"]').next` which no longer has a value.

Also corrected the `updated` value.