### PR TITLE
fix encoding for Nokogiri [TENJIN-24098]

### DIFF
--- a/lib/market_bot/play/app.rb
+++ b/lib/market_bot/play/app.rb
@@ -9,7 +9,7 @@ module MarketBot
       def self.parse(html, _opts = {})
         result = {}
 
-        doc = Nokogiri::HTML(html)
+        doc = Nokogiri::HTML(html, nil, 'UTF-8', &:noent)
 
         h2_additional_info = doc.at('h2:contains("Additional Information")')
         if h2_additional_info


### PR DESCRIPTION
Jira: https://adromance.atlassian.net/browse/TENJIN-24098

Nokogiri retruns the weirdly encoded app name for some Japanese apps suddenly from today without us making any change. For example,

```
妖怪美少女2択ゲーム
```
is the correct one.

```
å¦æªç¾å°å¥³2æã²ã¼ã 
```
is the wrong one. added option to handle the encoding properly when using Nokogiri. Tested in local and confirmed the fix.
