### PR TITLE
parse download properly from google play store page

### DIFF
--- a/lib/market_bot/play/app.rb
+++ b/lib/market_bot/play/app.rb
@@ -11,7 +11,7 @@ module MarketBot
 
         doc = Nokogiri::HTML(html, nil, 'UTF-8', &:noent)
 
-        h2_additional_info = doc.at('h2:contains("Additional Information")')
+        h2_additional_info = doc.at('h2:contains("About this game")')
         if h2_additional_info
           additional_info_parent         = h2_additional_info.parent.next.children.children
           node                           = additional_info_parent.at('div:contains("Updated")')

--- a/lib/market_bot/play/app.rb
+++ b/lib/market_bot/play/app.rb
@@ -11,7 +11,7 @@ module MarketBot
 
         doc = Nokogiri::HTML(html, nil, 'UTF-8', &:noent)
 
-        h2_additional_info = doc.at('h2:contains("About this game")')
+        h2_additional_info = doc.at('h2:contains("Additional Information")')
         if h2_additional_info
           additional_info_parent         = h2_additional_info.parent.next.children.children
           node                           = additional_info_parent.at('div:contains("Updated")')
@@ -20,17 +20,6 @@ module MarketBot
           result[:size]                  = node.children[1].text if node
           node                           = additional_info_parent.at('div:contains("Installs")')
           result[:installs]              = node.children[1].text if node
-          if result[:installs].blank?
-            # Look for install count near "Downloads"
-            doc.search('*').each do |element|
-              text = element.text.strip
-
-              if text.match?(/^\d+[KMB]?\+?$/) && element.parent&.text&.downcase&.include?('download')
-                result[:installs] = text
-                break
-              end
-            end
-          end
           node                           = additional_info_parent.at('div:contains("Current Version")')
           result[:current_version]       = node.children[1].text if node
           node                           = additional_info_parent.at('div:contains("Requires Android")')
@@ -82,6 +71,18 @@ module MarketBot
 
               node                      = node.parent.next
               result[:physical_address] = node.text if node
+            end
+          end
+        end
+        
+        if result[:installs].blank?
+          # Look for install count near "Downloads"
+          doc.search('*').each do |element|
+            text = element.text.strip
+
+            if text.match?(/^\d+[KMB]?\+?$/) && element.parent&.text&.downcase&.include?('download')
+              result[:installs] = text
+              break
             end
           end
         end

--- a/lib/market_bot/play/app.rb
+++ b/lib/market_bot/play/app.rb
@@ -20,6 +20,17 @@ module MarketBot
           result[:size]                  = node.children[1].text if node
           node                           = additional_info_parent.at('div:contains("Installs")')
           result[:installs]              = node.children[1].text if node
+          if result[:installs].blank?
+            # Look for install count near "Downloads"
+            doc.search('*').each do |element|
+              text = element.text.strip
+
+              if text.match?(/^\d+[KMB]?\+?$/) && element.parent&.text&.downcase&.include?('download')
+                result[:installs] = text
+                break
+              end
+            end
+          end
           node                           = additional_info_parent.at('div:contains("Current Version")')
           result[:current_version]       = node.children[1].text if node
           node                           = additional_info_parent.at('div:contains("Requires Android")')


### PR DESCRIPTION
Jira: https://adromance.atlassian.net/browse/TENJIN-24497

Currently we are not parsing `installs` properly from google play store page due to its layout change. The value will be something like "10M+", "500k+" etc on top of "Downloads" label.

![image](https://github.com/user-attachments/assets/b144cf71-51a6-4812-bdfe-78461d99ef9a)