### PR TITLE
fix parsing download property

### DIFF
--- a/lib/market_bot/play/app.rb
+++ b/lib/market_bot/play/app.rb
@@ -80,7 +80,7 @@ module MarketBot
           doc.search('*').each do |element|
             text = element.text.strip
 
-            if text.match?(/^\d+[KMB]?\+?$/) && element.parent&.text&.downcase&.include?('download')
+            if text.match?(/^\d+[KMB]?\+?$/) && element.parent&.text&.downcase&.include?('download') && (element.name == 'div' && element['class'])
               result[:installs] = text
               break
             end

--- a/lib/market_bot/play/app.rb
+++ b/lib/market_bot/play/app.rb
@@ -79,8 +79,9 @@ module MarketBot
           # Look for install count near "Downloads"
           doc.search('*').each do |element|
             text = element.text.strip
+            css_class = element['class']
 
-            if text.match?(/^\d+[KMB]?\+?$/) && element.parent&.text&.downcase&.include?('download') && (element.name == 'div' && element['class'])
+            if text.match?(/^\d+[KMB]?\+?$/) && element.parent&.text&.downcase&.include?('download') && (element.name == 'div' && css_class) && css_class != 'T4LgNb'
               result[:installs] = text
               break
             end

--- a/lib/market_bot/play/app.rb
+++ b/lib/market_bot/play/app.rb
@@ -81,7 +81,7 @@ module MarketBot
             text = element.text.strip
             css_class = element['class']&.strip
 
-            if text.match?(/^\d+[KMB]?\+?$/) && element.parent&.text&.downcase&.include?('download') && (element.name == 'div' && css_class) && css_class != 'T4LgNb'
+            if text.match?(/^\d+[KMB]?\+?$/) && element.parent&.text&.downcase&.include?('download') && (element.name == 'div' && css_class && css_class.length == 5)
               result[:installs] = text
               break
             end

--- a/lib/market_bot/play/app.rb
+++ b/lib/market_bot/play/app.rb
@@ -79,7 +79,7 @@ module MarketBot
           # Look for install count near "Downloads"
           doc.search('*').each do |element|
             text = element.text.strip
-            css_class = element['class']
+            css_class = element['class']&.strip
 
             if text.match?(/^\d+[KMB]?\+?$/) && element.parent&.text&.downcase&.include?('download') && (element.name == 'div' && css_class) && css_class != 'T4LgNb'
               result[:installs] = text


### PR DESCRIPTION
- For some apps like [this](https://play.google.com/store/apps/details?id=com.Ukun.ObbyCheeseTungSahur) one, we currently cannot get the download value (`1K+`) properly maybe because the google play html layout is different. Adding more strict condition to get the value.